### PR TITLE
Update Azure Static Web Apps workflow with build command

### DIFF
--- a/.github/workflows/azure-static-web-apps-nice-river-07c2fed03.yml
+++ b/.github/workflows/azure-static-web-apps-nice-river-07c2fed03.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          NODE_VERSION: 20
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NICE_RIVER_07C2FED03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -31,6 +33,7 @@ jobs:
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "dist/angular-tour-of-heroes/browser" # Built app content directory - optional
+          app_build_command: API_URL=${{ secrets.API_URL}} npm run build-with-api-url
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:
@@ -44,3 +47,4 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NICE_RIVER_07C2FED03 }}
           action: "close"
+


### PR DESCRIPTION
**Workflow configuration improvements:**

* Set the Node.js version to 20 for the `Azure/static-web-apps-deploy` action to ensure compatibility with the build and deployment process.
* Updated the `app_build_command` to inject the `API_URL` environment variable from GitHub secrets during the build step, allowing dynamic API endpoint configuration.

**Other:**

* Minor formatting adjustment in the workflow file (added a blank line).